### PR TITLE
UI treatment when there are no stale agreements

### DIFF
--- a/components/KPICards.tsx
+++ b/components/KPICards.tsx
@@ -143,10 +143,11 @@ export default function KPICards({ agreements }: KPICardsProps) {
         </CardHeader>
         <CardContent className="pt-0">
           <div className="text-3xl font-bold font-mono text-orange-500 mb-2">
-            {Math.round(
-              (kpiData.staleAgreementsCount / agreements.length) * 100,
-            )}
-            %
+            {agreements.length === 0
+              ? "--%"
+              : `${Math.round(
+                  (kpiData.staleAgreementsCount / agreements.length) * 100,
+                )}%`}
           </div>
           <div className="text-xs text-muted-foreground font-mono uppercase tracking-wide">
             % of Agreements Stagnant for &gt;12 Months


### PR DESCRIPTION
Current:
<img width="467" height="217" alt="image" src="https://github.com/user-attachments/assets/96b47f9c-a579-4b48-8652-c980e86b1b4e" />

Proposed:
<img width="462" height="218" alt="image" src="https://github.com/user-attachments/assets/2485f7ba-0ac6-4e69-bc89-4dd7180e04a8" />
