### PR TITLE
Fix repeated months in activity chart

### DIFF
--- a/components/ActivityChart.tsx
+++ b/components/ActivityChart.tsx
@@ -130,8 +130,10 @@ export default function ActivityChart({ agreements }: ActivityChartProps) {
     if (timeRange === "12months") {
       // Show last 12 months
       for (let i = 11; i >= 0; i--) {
-        const date = new Date();
-        date.setMonth(now.getMonth() - i);
+        // Start at the first day of the month. Using today's day can overflow
+        // shorter months (e.g. Feb 31 becomes Mar), which creates duplicate
+        // month keys and labels in the chart.
+        const date = new Date(now.getFullYear(), now.getMonth() - i, 1);
 
         const monthKey = `${date.getFullYear()}-${String(date.getMonth() + 1).padStart(2, "0")}`;
         const monthData = monthlyMap.get(monthKey) || {
@@ -245,11 +247,12 @@ export default function ActivityChart({ agreements }: ActivityChartProps) {
             return `${monthData.monthName} ${monthData.year}`;
           },
           label: function (context: {
-            parsed: { y: number };
+            parsed: { y: number | null };
             dataset: { label?: string };
           }) {
-            if (context.parsed.y === 0) return "";
-            return `${context.dataset.label || "Unknown"}: ${context.parsed.y} change${context.parsed.y === 1 ? "" : "s"}`;
+            const value = context.parsed.y ?? 0;
+            if (value === 0) return "";
+            return `${context.dataset.label || "Unknown"}: ${value} change${value === 1 ? "" : "s"}`;
           },
           footer: function (context: { dataIndex: number }[]) {
             const dataIndex = context[0].dataIndex;


### PR DESCRIPTION
## Summary
- Prevent month overflow from producing duplicate labels in the 12-month activity chart
- Handle nullable Chart.js tooltip values safely

## Verification
- `pnpm build` passes
- Pre-commit lint and Prettier hooks pass
- July 31 edge-case simulation produces 12 unique month keys

The repository currently has no test files; standalone TypeScript validation still reports existing Next.js dynamic-route parameter errors.